### PR TITLE
Added checkPreAuth call before checkPostAuth

### DIFF
--- a/src/LightSaml/SpBundle/Security/Authentication/Provider/LightsSamlSpAuthenticationProvider.php
+++ b/src/LightSaml/SpBundle/Security/Authentication/Provider/LightsSamlSpAuthenticationProvider.php
@@ -119,6 +119,7 @@ class LightsSamlSpAuthenticationProvider implements AuthenticationProviderInterf
         }
 
         if ($this->userChecker && $user instanceof UserInterface) {
+            $this->userChecker->checkPreAuth($user);
             $this->userChecker->checkPostAuth($user);
         }
 

--- a/tests/LightSaml/SpBundle/Tests/Security/Authentication/Provider/LightsSamlSpAuthenticationProviderTest.php
+++ b/tests/LightSaml/SpBundle/Tests/Security/Authentication/Provider/LightsSamlSpAuthenticationProviderTest.php
@@ -285,6 +285,10 @@ class LightsSamlSpAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
             ->willReturn($user);
 
         $userCheckerMock->expects($this->once())
+            ->method('checkPreAuth')
+            ->with($user);
+
+        $userCheckerMock->expects($this->once())
             ->method('checkPostAuth')
             ->with($user);
 


### PR DESCRIPTION
By adding this check it's possible to add the default checks isAccountNonLocked, isEnabled & isAccountNonExpired by using the AdvancedUserInterface.