### PR TITLE
Making DefaultController work with Symfony 2.3

### DIFF
--- a/src/LightSaml/SpBundle/Controller/DefaultController.php
+++ b/src/LightSaml/SpBundle/Controller/DefaultController.php
@@ -32,7 +32,7 @@ class DefaultController extends Controller
         $parties = $this->get('lightsaml.container.build')->getPartyContainer()->getIdpEntityDescriptorStore()->all();
 
         if (count($parties) == 1) {
-            return $this->redirectToRoute('lightsaml_sp.login', ['idp' => $parties[0]->getEntityID()]);
+            return $this->redirect($this->generateUrl('lightsaml_sp.login', ['idp' => $parties[0]->getEntityID()]));
         }
 
         return $this->render('LightSamlSpBundle::discovery.html.twig', [
@@ -44,7 +44,7 @@ class DefaultController extends Controller
     {
         $idpEntityId = $request->get('idp');
         if (null === $idpEntityId) {
-            return $this->redirectToRoute($this->container->getParameter('lightsaml_sp.route.discovery'));
+            return $this->redirect($this->generateUrl($this->container->getParameter('lightsaml_sp.route.discovery')));
         }
 
         $profile = $this->get('ligthsaml.profile.login_factory')->get($idpEntityId);


### PR DESCRIPTION
Pre Symfony 2.6 (I think) `$this->redirectToRoute()` was satisfied by `$this->redirect($this->generateUrl())`. Making this edit to work with Symfony 2.3. It might be worthwhile to check version by looking at `Symfony\Component\HttpKernel\Kernel::VERSION`, as per http://stackoverflow.com/questions/16846189/how-to-know-which-version-of-symfony-i-have#16846325