### PR TITLE
Use username mapper to resolve username when creating a default user

### DIFF
--- a/src/LightSaml/SpBundle/Security/Authentication/Provider/LightsSamlSpAuthenticationProvider.php
+++ b/src/LightSaml/SpBundle/Security/Authentication/Provider/LightsSamlSpAuthenticationProvider.php
@@ -11,8 +11,6 @@
 
 namespace LightSaml\SpBundle\Security\Authentication\Provider;
 
-use LightSaml\ClaimTypes;
-use LightSaml\SamlConstants;
 use LightSaml\SpBundle\Security\Authentication\Token\SamlSpResponseToken;
 use LightSaml\SpBundle\Security\Authentication\Token\SamlSpToken;
 use LightSaml\SpBundle\Security\Authentication\Token\SamlSpTokenFactoryInterface;
@@ -207,36 +205,11 @@ class LightsSamlSpAuthenticationProvider implements AuthenticationProviderInterf
      */
     private function createDefaultUser(SamlSpResponseToken $token)
     {
-        if ($token->getResponse()->getFirstAssertion() &&
-            $token->getResponse()->getFirstAssertion()->getSubject() &&
-            $token->getResponse()->getFirstAssertion()->getSubject()->getNameID() &&
-            $token->getResponse()->getFirstAssertion()->getSubject()->getNameID()->getFormat() != SamlConstants::NAME_ID_FORMAT_TRANSIENT &&
-            $token->getResponse()->getFirstAssertion()->getSubject()->getNameID()->getValue()
-        ) {
-            return $token->getResponse()->getFirstAssertion()->getSubject()->getNameID()->getValue();
+        if (null === $this->usernameMapper) {
+            return null;
         }
 
-        if ($token->getResponse()->getFirstAssertion() &&
-            $attributeStatement = $token->getResponse()->getFirstAssertion()->getFirstAttributeStatement()
-        ) {
-            $names = [
-                ClaimTypes::COMMON_NAME,
-                ClaimTypes::EMAIL_ADDRESS,
-                ClaimTypes::WINDOWS_ACCOUNT_NAME,
-                ClaimTypes::ADFS_1_EMAIL,
-                ClaimTypes::UPN,
-                ClaimTypes::ADFS_1_UPN,
-            ];
-
-            foreach ($names as $name) {
-                $attribute = $attributeStatement->getFirstAttributeByName($name);
-                if ($attribute && $attribute->getFirstAttributeValue()) {
-                    return $attribute->getFirstAttributeValue();
-                }
-            }
-        }
-
-        return null;
+        return $this->usernameMapper->getUsername($token->getResponse());
     }
 
     /**

--- a/tests/LightSaml/SpBundle/Tests/Security/Authentication/Provider/LightsSamlSpAuthenticationProviderTest.php
+++ b/tests/LightSaml/SpBundle/Tests/Security/Authentication/Provider/LightsSamlSpAuthenticationProviderTest.php
@@ -189,6 +189,10 @@ class LightsSamlSpAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
             )
         );
 
+        $usernameMapperMock->expects($this->exactly(2))
+            ->method('getUsername')
+            ->willReturn($nameIdValue);
+
         $authenticatedToken = $provider->authenticate($token);
 
         $this->assertTrue($authenticatedToken->isAuthenticated());
@@ -225,6 +229,10 @@ class LightsSamlSpAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
                 ->addAttribute(new Attribute(ClaimTypes::EMAIL_ADDRESS, $email = 'email@domain.com'))
             )
         );
+
+        $usernameMapperMock->expects($this->exactly(2))
+            ->method('getUsername')
+            ->willReturn($email);
 
         $authenticatedToken = $provider->authenticate($token);
 


### PR DESCRIPTION
This pull request originates from the situation where I had the `force` option enabled in the firewall and then wanted to control the username resolving by setting my own list of attributes on the `light_saml_sp.username_mapper` configuration.

This wasn't working and it turned out that the username mapper was never used when the `LightsSamlSpAuthenticationProvider` wants to create a default user. In fact, the logic used in the `createDefaultUser` method looks very similar to the logic of the `SimpleUsernameMapper`. As far as my interpretation of this bundle goes there's no necessity why this logic should be duplicated and could possibly cause unexpected behavior, as described above.

That's why I'm proposing to use the username mapper for resolving the username when a default user should be created. In my opinion this change has three main benefits:
* There's less unexpected behavior because there's a single source of 'truth' when it comes to resolving a username.
* The configuration options to manipulate the username mapper can now also be used when creating a default user.
* Because the logic for resolving a username is more or less the same between the removed lines of code and the `SimpleUsernameMapper`, this will most likely not affect current implementations.

Would like to know what you think of it!