### PR TITLE
private->protected in SimpleUsernameMapper

### DIFF
--- a/src/LightSaml/SpBundle/Security/User/SimpleUsernameMapper.php
+++ b/src/LightSaml/SpBundle/Security/User/SimpleUsernameMapper.php
@@ -20,7 +20,7 @@ class SimpleUsernameMapper implements UsernameMapperInterface
     const NAME_ID = '@name_id@';
 
     /** @var string[] */
-    private $attributes;
+    protected $attributes;
 
     /**
      * @param string[] $attributes
@@ -52,7 +52,7 @@ class SimpleUsernameMapper implements UsernameMapperInterface
      *
      * @return null|string
      */
-    private function getUsernameFromAssertion(Assertion $assertion)
+    protected function getUsernameFromAssertion(Assertion $assertion)
     {
         foreach ($this->attributes as $attributeName) {
             if (self::NAME_ID == $attributeName) {


### PR DESCRIPTION
Easier to extend

I extended it in my child bundle and it currently duplicates `$attributes` because of `private`

```php
<?php

namespace Tema\Api\LightSamlBundle\Security\User;

use LightSaml\Model\Assertion\Assertion;
use LightSaml\Model\Protocol\Response;
use LightSaml\SamlConstants;
use LightSaml\SpBundle\Security\User\SimpleUsernameMapper as SimpleUsernameMapperBase;

class PersistentUsernameMapper extends SimpleUsernameMapperBase
{
    const NAME_ID_FORMAT = SamlConstants::NAME_ID_FORMAT_PERSISTENT;

    /** @var string[] */
    protected $attributes;

    /**
     * @param string[] $attributes
     */
    public function __construct(array $attributes)
    {
        parent::__construct($attributes);

        $this->attributes = $attributes;
    }

    /**
     * @param Response $response
     *
     * @return string|null
     */
    public function getUsername(Response $response)
    {
        foreach ($response->getAllAssertions() as $assertion) {
            $username = $this->getUsernameFromAssertion($assertion);
            if ($username) {
                return $username;
            }
        }

        return null;
    }

    /**
     * @param Assertion $assertion
     *
     * @return null|string
     */
    protected function getUsernameFromAssertion(Assertion $assertion)
    {
        foreach ($this->attributes as $attributeName) {
            if (self::NAME_ID == $attributeName) {
                if ($assertion->getSubject() &&
                    $assertion->getSubject()->getNameID() &&
                    $assertion->getSubject()->getNameID()->getValue() &&
                    $assertion->getSubject()->getNameID()->getFormat() === self::NAME_ID_FORMAT
                ) {
                    return $assertion->getSubject()->getNameID()->getValue();
                }
            } else {
                foreach ($assertion->getAllAttributeStatements() as $attributeStatement) {
                    $attribute = $attributeStatement->getFirstAttributeByName($attributeName);
                    if ($attribute && $attribute->getFirstAttributeValue()) {
                        return $attribute->getFirstAttributeValue();
                    }
                }
            }
        }

        return null;
    }
}

```