### PR TITLE
Support for Symfony 4.1

### DIFF
--- a/src/LightSaml/SpBundle/Controller/DefaultController.php
+++ b/src/LightSaml/SpBundle/Controller/DefaultController.php
@@ -35,7 +35,7 @@ class DefaultController extends Controller
             return $this->redirect($this->generateUrl('lightsaml_sp.login', ['idp' => $parties[0]->getEntityID()]));
         }
 
-        return $this->render('LightSamlSpBundle::discovery.html.twig', [
+        return $this->render('@LightSamlSp/discovery.html.twig', [
             'parties' => $parties,
         ]);
     }
@@ -60,7 +60,7 @@ class DefaultController extends Controller
     {
         $ssoState = $this->get('lightsaml.container.build')->getStoreContainer()->getSsoStateStore()->get();
 
-        return $this->render('LightSamlSpBundle::sessions.html.twig', [
+        return $this->render('@LightSamlSp/sessions.html.twig', [
             'sessions' => $ssoState->getSsoSessions(),
         ]);
     }

--- a/src/LightSaml/SpBundle/Resources/config/routing.yml
+++ b/src/LightSaml/SpBundle/Resources/config/routing.yml
@@ -1,18 +1,18 @@
 lightsaml_sp.metadata:
     path: /metadata.xml
-    defaults: { _controller: LightSamlSpBundle:Default:metadata }
+    defaults: { _controller: LightSaml\SpBundle\Controller\DefaultController::metadataAction }
 
 lightsaml_sp.discovery:
     path: /discovery
-    defaults: { _controller: LightSamlSpBundle:Default:discovery }
+    defaults: { _controller: LightSaml\SpBundle\Controller\DefaultController::discoveryAction }
 
 lightsaml_sp.login:
     path: /login
-    defaults: { _controller: LightSamlSpBundle:Default:login }
+    defaults: { _controller: LightSaml\SpBundle\Controller\DefaultController::loginAction}
 
 lightsaml_sp.login_check:
     path: /login_check
 
 lightsaml_sp.sessions:
     path: /sessions
-    defaults: { _controller: LightSamlSpBundle:Default:sessions }
+    defaults: { _controller: LightSaml\SpBundle\Controller\DefaultController::sessionsAction }


### PR DESCRIPTION
Updates to support Symfony 4.1:
* Use native Twig references for templates, this makes the template compatible with recent Symfony versions.
* Correct controllers references to remove deprecations with Symfony 4.1

All tested and works good with SF 2.7, SF 3.0 and SF 4.1