### PR TITLE
Add RelayState parameter to login route

### DIFF
--- a/src/LightSaml/SpBundle/Controller/DefaultController.php
+++ b/src/LightSaml/SpBundle/Controller/DefaultController.php
@@ -49,6 +49,12 @@ class DefaultController extends Controller
 
         $profile = $this->get('ligthsaml.profile.login_factory')->get($idpEntityId);
         $context = $profile->buildContext();
+
+        $relayState = $request->get('RelayState');
+        if (null !== $relayState) {
+            $context->setRelayState($relayState);
+        }
+
         $action = $profile->buildAction();
 
         $action->execute($context);

--- a/src/LightSaml/SpBundle/Resources/views/discovery.html.twig
+++ b/src/LightSaml/SpBundle/Resources/views/discovery.html.twig
@@ -10,7 +10,7 @@
 <p><small>Choose one</small></p>
 {% for idp in parties %}
     {% if idp.allIdpSsoDescriptors %}
-        <p><a data-idp="{{ idp.entityID }}" href="{{ path('lightsaml_sp.login', {idp: idp.entityID}) }}">{{ idp.entityID }}</a></p>
+        <p><a data-idp="{{ idp.entityID }}" href="{{ path('lightsaml_sp.login', params|merge({idp: idp.entityID})) }}">{{ idp.entityID }}</a></p>
     {% endif %}
 {% else %}
     <p>There is no IDP configured</p>


### PR DESCRIPTION
The RelayState parameter is a common way for a frontend to tell the backend to which URL it should be redirected after a successful SAML login.

This RelayState parameter is correctly handled by lightsaml, but was ignored by the SpBundle routes.

This PR adds RelayState handling in login and discovery routes.